### PR TITLE
Fix `.get($url)` when error

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -32,7 +32,7 @@
    "authors" : [
       "Brian Duggan <bduggan@matatu.org>"
    ],
-   "version" : "0.0.4",
+   "version" : "0.0.5",
    "license" : "MIT",
    "description" : "AWS S3 Client"
 }

--- a/lib/WebService/AWS/S3.pm6
+++ b/lib/WebService/AWS/S3.pm6
@@ -131,9 +131,12 @@ class S3 {
   }
 
   multi method get(S3::Object:D $object) {
-    my $res = self.do-request(:path($object.key), :subdomain($object.bucket.name));
-    # say $res.header.fields.map({ .name => .values}).perl;
-    return $res.content;
+    if my $res = self.do-request(:path($object.key), :subdomain($object.bucket.name)) {
+        $res.content;
+    }
+    else {
+        Nil
+    }
   }
 
   multi method get(Str $url) {


### PR DESCRIPTION
Currently if there is an error on `get($url)` it dies with (for example):

	Error: 404 Not Found NoSuchKey
	<?xml version="1.0" encoding="UTF-8"?>
	<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>hello/wxrld.txt</Key><RequestId>Y2BS7JSE0D7ZTNWD</RequestId><HostId>SLhXQenrYg2emKd7LadmdDbLk6sjC/TAaWP7qcziLeavjhWRM8WcndeFcXpyJoKbRzO9PcGJFmI=</HostId></Error>
	No such method 'content' for invocant of type 'Any'
	  in method get at /home/jonathan/.raku/sources/779A68B2770DBA6C868F3B8802DD2388BC6F6EA9 (WebService::AWS::S3) line 136
	  in method get at /home/jonathan/.raku/sources/779A68B2770DBA6C868F3B8802DD2388BC6F6EA9 (WebService::AWS::S3) line 141
	  in block <unit> at xx line 13

Because the `.get($object)` returns Nil thus the attempt to call
.content fails.

THis just skips the attempt if `$res` is undefined.