### PR TITLE
Send (and sign,) x-amz-security-token if provided.

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -33,7 +33,7 @@
    "authors" : [
       "Brian Duggan <bduggan@matatu.org>"
    ],
-   "version" : "0.0.5",
+   "version" : "0.0.6",
    "license" : "MIT",
    "description" : "AWS S3 Client"
 }

--- a/lib/WebService/AWS/S3.pm6
+++ b/lib/WebService/AWS/S3.pm6
@@ -24,6 +24,7 @@ class S3 {
   has $.region = 'us-east-1';
   has $.secret-access-key = %*ENV<AWS_SECRET_ACCESS_KEY> || die "Please set AWS_SECRET_ACCESS_KEY";
   has $.access-key-id = %*ENV<AWS_ACCESS_KEY_ID> || die "Please set AWS_ACCESS_KEY_ID";
+  has Str $.security-token = ( %*ENV<AWS_SESSION_TOKEN> // Str );
   has $.ua = HTTP::UserAgent.new;
   has $!req;
   has $!res;
@@ -37,11 +38,13 @@ class S3 {
       :Host( $host ),
       :X-Amz-Date( timestamp($now) ),
       :X-AMZ-Content-SHA256( $sha ),
+      ( x-amz-security-token => $_ with $.security-token ),
       ;
     my $req = S3::Request.new(
        :$.secret-access-key,
        :$.region,
        :$.access-key-id,
+       :$.security-token,
        :$path
        :$query-string,
        :$body,

--- a/lib/WebService/AWS/S3/Request.pm6
+++ b/lib/WebService/AWS/S3/Request.pm6
@@ -12,6 +12,7 @@ has %.headers;
 
 has $.access-key-id is required;
 has $.secret-access-key;
+has Str $.security-token;
 has $.region is required;
 has $.service = 's3';
 has DateTime $.date is required;
@@ -62,6 +63,9 @@ method canonical-uri {
 method canonical-headers {
     %.headers<X-Amz-Date> //= timestamp(self.date);
     %.headers<Host> //= self.host;
+    if $.security-token.defined && not %.headers<x-amz-security-token>:exists {
+       %.headers<x-amz-security-token> = $.security-token;
+    }
     my %canonical = map { .key.lc => .value }, %.headers;
     %canonical;
 }


### PR DESCRIPTION
If the client is using "temporary" credentials provided by the "Security Token Service"
( using, for example, [Kivuli](https://github.com/jonathanstowe/Kivuli),) the security
token *must* be provided and be part of the signed headers, otherwise the client will
receive "InvalidAccessKeyId".

This is tested and found to work in an EC2 instance.

Fixes #8